### PR TITLE
fix blocky renderer when camera is too close to penisobj

### DIFF
--- a/IO_Demosaic/IO_Demosaic.cs
+++ b/IO_Demosaic/IO_Demosaic.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx;
+using BepInEx;
 using HarmonyLib;
 using UnityEngine;
 
@@ -9,7 +9,7 @@ namespace IO_Demosaic
     public class IO_Demosaic : BaseUnityPlugin
     {
         // Set version in BepInEx and in AssemblyInfo
-        public const string Version = "1.1";
+        public const string Version = "1.2";
         public IO_Demosaic()
         {
             // Patch Everything
@@ -26,9 +26,10 @@ namespace IO_Demosaic
 
         // Disabling Mosaic Object in Characters
         [HarmonyPostfix, HarmonyPatch(typeof(MozaicSetUp), "Start")]
-        private static void CharacterDemosaic(Renderer ___MozaObj)
+        private static void CharacterDemosaic(Renderer ___MozaObj, MozaicSetUp __instance)
         {
-            ___MozaObj.enabled=false;
+            ___MozaObj.enabled = false;
+            __instance.enabled = false;
         }
 
         // Disabling Mosaic Object in X-ray window

--- a/IO_Demosaic/IO_Demosaic.cs
+++ b/IO_Demosaic/IO_Demosaic.cs
@@ -9,7 +9,7 @@ namespace IO_Demosaic
     public class IO_Demosaic : BaseUnityPlugin
     {
         // Set version in BepInEx and in AssemblyInfo
-        public const string Version = "1.2";
+        public const string Version = "1.1";
         public IO_Demosaic()
         {
             // Patch Everything


### PR DESCRIPTION
The patched part, for reference
```
private void Update()
{
	MozaObj.material.color = Color.white;
	CameraPos = Vector3.Distance(MainCamera.transform.position, PenisBone.transform.position);
	MozaObj.sharedMaterial.SetFloat("_BlockSize", Mathf.Clamp((CameraPos - 20f) * -1f + Mathf.Lerp(10f, 0f, (Camera.main.fieldOfView - 10f) / 100f * 2f), 12f, 30f) * GameClass.mozamoza);
	IL = Mathf.InverseLerp(1f, 10f, CameraPos);
	if (base.gameObject.name == "PC00")
	{
		PenisObj.sharedMaterial.SetFloat("_Moza", Mathf.Lerp(30f, 1000f, IL) * GameClass.mozamoza);
	}
}
```
in MozaicSetUp